### PR TITLE
Update to the latest twingate client

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   version:
     description: 'Twingate Client Version'
-    default: 1.0.15.9013
+    default: 1.0.27.19340
     required: false
 runs:
   using: "composite"


### PR DESCRIPTION
Latest windows client is 1.0.27.19340

<details>
<summary>Request</summary>

```
GET /download/windows HTTP/1.1
Host: api.twingate.com
Connection: close
User-Agent: RapidAPI/4.1.5 (Macintosh; OS X/13.2.1) GCDHTTPRequest
```
</details>
<details>
<summary>Response</summary>

```
HTTP/1.1 302 Found
server: gunicorn
date: Wed, 22 Mar 2023 20:17:51 GMT
content-type: text/html; charset=utf-8
location: https://binaries.twingate.com/client/windows/versions/1.0.27.19340/TwingateWindowsInstaller.exe
allow: GET, HEAD, OPTIONS
x-frame-options: DENY
Content-Length: 0
vary: Cookie
strict-transport-security: max-age=31536000; includeSubDomains
x-content-type-options: nosniff
referrer-policy: same-origin
cross-origin-opener-policy: same-origin
via: 1.1 google
Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
Connection: close
```
</details>